### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "clean": "gts clean",
     "compile": "tsc",
     "fix": "gts fix",
-    "prepare": "yarn.cmd run compile",
-    "pretest": "yarn.cmd run compile",
-    "posttest": "yarn.cmd run lint"
+    "prepare": "yarn run compile",
+    "pretest": "yarn run compile",
+    "posttest": "yarn run lint"
   },
   "dependencies": {
     "commander": "^10.0.0",


### PR DESCRIPTION
The commands were using `yarn.cmd`, assuming it was running on windows. Removing the `.cmd` allows it to run on linux, and should still continue run on windows.